### PR TITLE
Fix regex warning

### DIFF
--- a/lib/openapi_client/models/bank_account.rb
+++ b/lib/openapi_client/models/bank_account.rb
@@ -1,7 +1,7 @@
 =begin
 #Lob
 
-#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+#The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
 
 The version of the OpenAPI document: 1.3.0
 Contact: lob-openapi@lob.com
@@ -15,7 +15,7 @@ require 'time'
 
 module Lob
   class BankAccount
-    # An internal description that identifies this resource. Must be no longer than 255 characters. 
+    # An internal description that identifies this resource. Must be no longer than 255 characters.
     attr_accessor :description
 
     # Must be a [valid US routing number](https://www.frbservices.org/index.html).
@@ -257,7 +257,7 @@ module Lob
         invalid_properties.push("invalid value for \"id\", must conform to the pattern #{pattern}.")
       end
 
-      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      pattern = lob_assets_url_regex
       if !@signature_url.nil? && @signature_url !~ pattern
         invalid_properties.push("invalid value for \"signature_url\", must conform to the pattern #{pattern}.")
       end
@@ -293,7 +293,7 @@ module Lob
       return false if @signatory.to_s.length > 30
       return false if @id.nil?
       return false if @id !~ Regexp.new(/^bank_[a-zA-Z0-9]+$/)
-      return false if !@signature_url.nil? && @signature_url !~ Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      return false if !@signature_url.nil? && @signature_url !~ lob_assets_url_regex
       return false if @date_created.nil?
       return false if @date_modified.nil?
       return false if @object.nil?
@@ -392,7 +392,7 @@ module Lob
     # Custom attribute writer method with validation
     # @param [Object] signature_url Value to be assigned
     def signature_url=(signature_url)
-      pattern = Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+/)
+      pattern = lob_assets_url_regex
       if !signature_url.nil? && signature_url !~ pattern
         fail ArgumentError, "invalid value for \"signature_url\", must conform to the pattern #{pattern}."
       end
@@ -569,6 +569,10 @@ module Lob
       else
         value
       end
+    end
+
+    def lob_assets_url_regex
+      Regexp.new(/^https:\/\/lob-assets.com\/(letters|postcards|bank-accounts|checks|self-mailers|cards)\/[a-z]{3,4}_[a-z0-9]{15,16}(''|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)\?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9\-_]+/)
     end
 
   end


### PR DESCRIPTION
![image](https://github.com/hellobrightline/lob-ruby/assets/852709/1f5d062d-aaad-40b5-a4ad-47704df66074)

I think my plan is to make a separate branch with this change from my personal fork to try to get this upstream. Since apparently they won't take my ruby 3 PR. 🤷 

Or we can just run an increasingly forked version of lob-ruby gem. 